### PR TITLE
Fixed newline not being added to header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Newline character not being added to the Lua file header in some cases ([#62](https://github.com/argon-rbx/argon/pull/62))
+
 ## [2.0.9] - 2024-06-25
 
 ### Added

--- a/src/middleware/lua.rs
+++ b/src/middleware/lua.rs
@@ -107,7 +107,7 @@ pub fn write_lua(mut properties: Properties, path: &Path, vfs: &Vfs) -> Result<P
 
 	new_header.pop();
 
-	if !new_header.is_empty() && !source.starts_with('\n') {
+	if !new_header.is_empty() /*&& !source.starts_with('\n')*/ {
 		new_header += "\n";
 	}
 

--- a/src/middleware/lua.rs
+++ b/src/middleware/lua.rs
@@ -107,7 +107,7 @@ pub fn write_lua(mut properties: Properties, path: &Path, vfs: &Vfs) -> Result<P
 
 	new_header.pop();
 
-	if !new_header.is_empty() /*&& !source.starts_with('\n')*/ {
+	if !new_header.is_empty() {
 		new_header += "\n";
 	}
 
@@ -119,6 +119,10 @@ pub fn write_lua(mut properties: Properties, path: &Path, vfs: &Vfs) -> Result<P
 
 		if header.len() == header.match_indices(' ').count() {
 			header.clear();
+
+			if source.starts_with('\n') {
+				source.remove(0);
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixed header tags like `--disable`, `--client`, etc. not inserting a newline on a few occasions by commenting out a condition in lua.rs. This makes it ignore if there is already a newline in the source and adds a new one anyway, but it is preferable to it not adding a newline at all and throwing a bunch of errors (which is what happened in my case).